### PR TITLE
136 feat login native

### DIFF
--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -20,7 +20,10 @@ export default function Error({
       <h2 className="font-heading-28 mb-[20px] text-center">
         데이터를 받아오는 도중 오류가 발생했어요 !
       </h2>
-      <pre className="px-4">{error.message}</pre>
+      <pre className="w-full max-w-full overflow-auto whitespace-pre-wrap break-words rounded bg-white p-4 text-sm text-red-600">
+        {error.message}
+      </pre>
+
       <div className="flex w-full items-center gap-x-2">
         <Button
           className="w-full"

--- a/src/hooks/use-native-login.tsx
+++ b/src/hooks/use-native-login.tsx
@@ -1,0 +1,98 @@
+import { toast } from '@/components/ui/use-toast';
+import { tokenRenewal } from '@/service/client-actions/notification';
+import { setCookie } from 'cookies-next';
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+
+const useNativeLogin = ({ code, state }: { code: string; state: string }) => {
+  const router = useRouter();
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (window.ReactNativeWebView === undefined) return;
+    window.receiveAuthData = async (authData: any) => {
+      try {
+        // window.alert(`data: ${authData.accessToken} ${authData.identity}`);
+        if (authData === undefined) {
+          toast({
+            title: '서버에서 오류가 발생하였습니다.',
+            variant: 'destructive',
+          });
+        }
+        if (authData.notificationsEnabled === true) {
+          await tokenRenewal(authData.id);
+        }
+        if (!authData.identity || !authData.accessToken)
+          throw Error('토큰 오류');
+
+        if (!authData?.signUpCompleted) {
+          // alert('회원가입 페이지로 이동');
+
+          router.push(`/register`);
+
+          setCookie('oauthId', authData.oauthUserId);
+        } else {
+          setCookie('identity', authData.identity);
+          setCookie('accessToken', authData.accessToken);
+          if (authData.notificationsEnabled === true) {
+            await tokenRenewal(authData.id);
+          }
+
+          // alert('홈 이동');
+          router.push('/');
+        }
+      } catch (error) {
+        console.error('메시지 처리 중 에러:', error);
+        toast({
+          title: '서버에서 오류가 발생하였습니다.',
+          variant: 'destructive',
+        });
+      } finally {
+        setLoading(false);
+      }
+      // return 'receiveAuthData';
+    };
+
+    window.ReactNativeWebView?.postMessage(
+      JSON.stringify({
+        type: 'READY',
+      }),
+    );
+  }, [router]);
+
+  useEffect(() => {
+    if (loading) return;
+    if (window.ReactNativeWebView === undefined) return;
+
+    const authenticate = async () => {
+      if (code && state) {
+        setLoading(true);
+        try {
+          if (window.ReactNativeWebView) {
+            window.ReactNativeWebView.postMessage(
+              JSON.stringify({
+                type: 'AUTH_CODE',
+                payload: {
+                  code,
+                  state,
+                },
+              }),
+            );
+          }
+        } catch (error) {
+          console.error('Error during authentication:', error);
+          // 오류 시 에러 페이지로 이동하거나 에러 처리 가능
+        } finally {
+          setLoading(false);
+        }
+      }
+    };
+
+    authenticate();
+  }, [code, loading, router, state]);
+
+  return {
+    loading,
+  };
+};
+export default useNativeLogin;

--- a/src/hooks/use-web-login.ts
+++ b/src/hooks/use-web-login.ts
@@ -1,0 +1,53 @@
+import { toast } from '@/components/ui/use-toast';
+import { sendCodeToBackend } from '@/service/auth-service';
+import { tokenRenewal } from '@/service/client-actions/notification';
+import { setCookie } from 'cookies-next';
+import { useRouter } from 'next/navigation';
+
+import { useEffect, useState } from 'react';
+
+const useWebLogin = ({ code, state }: { code: string; state: string }) => {
+  const router = useRouter();
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (window.ReactNativeWebView) return;
+
+    const authenticate = async () => {
+      if (code && state) {
+        setLoading(true);
+        try {
+          const data = await sendCodeToBackend(code, state);
+          if (data === undefined) {
+            toast({
+              title: '서버에서 오류가 발생하였습니다.',
+              variant: 'destructive',
+            });
+          }
+
+          if (!data?.signUpCompleted) {
+            router.push(`/register`);
+            setCookie('oauthId', data.oauthUserId);
+          } else {
+            setCookie('identity', data.identity);
+            setCookie('accessToken', data.accessToken);
+            if (data.notificationsEnabled === true) {
+              await tokenRenewal(data.id);
+            }
+            router.push('/');
+          }
+        } catch (error) {
+          console.error('Error during authentication:', error);
+          // 오류 시 에러 페이지로 이동하거나 에러 처리 가능
+        } finally {
+          setLoading(false);
+        }
+      }
+    };
+
+    authenticate();
+  }, [code, router, state]);
+  return { loading };
+};
+
+export default useWebLogin;


### PR DESCRIPTION
> ### PR 제목은 핵심 변경 사항을 요약해주세요.

---

## 🙋‍ Summary (요약)

### 리액트 네이티브 로그인 로직 추가

- 리액트 네이티브 -> 웹뷰: `injectJavaScript` 코드로 통신
- 웹뷰 -> 리액트 네이티브: `window.ReactNativeWebView.postMessage`로 메세지 전달

추후 리액트 네이티브 환경인지 웹 환경인지 판단하는 로직 수정이 필요할 것 같습니다. (빌드 시점에 환경변수로 관리할지?)

## 🤔 Describe your Change (변경사항)

- 기존 웹 로그인 로직 `useWebLogin` 훅으로 분리
- 에러 페이지의 에러 메세지 부분이 잘리지 않고 잘 보이게 ui를 수정했습니다.

## 🔗 Issue number and link (참고)

- #136 

